### PR TITLE
Bugs: Default project ID, Active projects

### DIFF
--- a/DancingGoat/Areas/Admin/AppSettingProvider.cs
+++ b/DancingGoat/Areas/Admin/AppSettingProvider.cs
@@ -14,7 +14,7 @@ namespace DancingGoat.Areas.Admin
         private static readonly Configuration _configuration = WebConfigurationManager.OpenWebConfiguration("~");
         private static DateTime? _subscriptionExpiresAt;
         private static Guid? _projectId;
-        private static Guid? _sharedProjectId;
+        private static Guid? _defaultProjectId;
         private static string _previewToken;
 
         internal static DateTime? SubscriptionExpiresAt
@@ -99,17 +99,17 @@ namespace DancingGoat.Areas.Admin
         {
             get
             {
-                if (_projectId.HasValue)
+                if (_defaultProjectId.HasValue)
                 {
-                    return _sharedProjectId;
+                    return _defaultProjectId;
                 }
                 else
                 {
                     if (Guid.TryParse(ConfigurationManager.AppSettings["DefaultProjectId"], out Guid projectId))
                     {
-                        _sharedProjectId = projectId;
+                        _defaultProjectId = projectId;
 
-                        return _sharedProjectId;
+                        return _defaultProjectId;
                     }
                     else
                     {

--- a/DancingGoat/Areas/Admin/Controllers/SelfConfigController.cs
+++ b/DancingGoat/Areas/Admin/Controllers/SelfConfigController.cs
@@ -129,7 +129,7 @@ namespace DancingGoat.Areas.Admin.Controllers
                             {
                                 AddSecurityInfoToViewBag();
 
-                                return View("SelectOrCreateProject", new SelectProjectViewModel { Projects = results.Projects });
+                                return View("SelectOrCreateProject", new SelectProjectViewModel { Projects = results.Projects.Where(p => p.Inactive == false) });
                             }
                             else
                             {
@@ -153,7 +153,7 @@ namespace DancingGoat.Areas.Admin.Controllers
                         {
                             ViewBag.EndAt = results.EndAt;
 
-                            return View(results.Status.ToString(), new SelectProjectViewModel { Projects = results.Projects });
+                            return View(results.Status.ToString(), new SelectProjectViewModel { Projects = results.Projects.Where(p => p.Inactive == false) });
                         }
                     }
                 }
@@ -228,14 +228,14 @@ namespace DancingGoat.Areas.Admin.Controllers
                             {
                                 AddSecurityInfoToViewBag();
 
-                                return View("SelectOrCreateProject", new SelectProjectViewModel { Projects = results.Projects });
+                                return View("SelectOrCreateProject", new SelectProjectViewModel { Projects = results.Projects.Where(p => p.Inactive == false) });
                             }
                         }
                         else
                         {
                             ViewBag.EndAt = results.EndAt;
 
-                            return View(results.Status.ToString(), new SelectProjectViewModel { Projects = results.Projects });
+                            return View(results.Status.ToString(), new SelectProjectViewModel { Projects = results.Projects.Where(p => p.Inactive == false) });
                         }
                     }
                 }


### PR DESCRIPTION
Pressing "Use the shared project" no longer causes an exception. Project selector now correctly shows just active projects.