### PR TITLE
Added multilingual asset descriptions

### DIFF
--- a/DancingGoat/Helpers/Extensions/HtmlHelperExtensions.cs
+++ b/DancingGoat/Helpers/Extensions/HtmlHelperExtensions.cs
@@ -28,7 +28,7 @@ namespace DancingGoat.Helpers.Extensions
             var image = new TagBuilder("img");
             image.MergeAttribute("src", asset.Url);
             image.AddCssClass(cssClass);
-            string titleToUse = title ?? asset.Name ?? string.Empty;
+            string titleToUse = title ?? asset.Description ?? string.Empty;
             image.MergeAttribute("alt", titleToUse);
             image.MergeAttribute("title", titleToUse);
 


### PR DESCRIPTION
As we've added multilingual support for language description, I've noticed that assets alt text is loaded based on Name instead of Description which is how it should be. So I've changed it.