### PR TITLE
CMP-595 - Fix edit panel state after refresh in Firefox

### DIFF
--- a/DancingGoat/Views/Shared/EditModePanel.cshtml
+++ b/DancingGoat/Views/Shared/EditModePanel.cshtml
@@ -4,7 +4,7 @@
     <div>
         <div class="edit-mode-panel__toggle">
             <label class="switch">
-                <input id="edit-mode-switch" type="checkbox" onchange="toggleEditMode(this.checked)">
+                <input id="edit-mode-switch" type="checkbox" onchange="toggleEditMode(this.checked)" autocomplete="off">
                 <span class="slider round"></span>
             </label>
         </div>


### PR DESCRIPTION
After refresh in Firefox there was cached state for edit panel toggle checkbox.