### PR TITLE
Prevent server errors

### DIFF
--- a/DancingGoat/Views/Shared/HeadersMetadata.cshtml
+++ b/DancingGoat/Views/Shared/HeadersMetadata.cshtml
@@ -5,7 +5,7 @@
 <meta property="og:title" content="@Model.MetadataOgTitle" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="@(Request.Url?.AbsoluteUri)" />
-<meta property="og:image" content="@(Model.MetadataOgImage.FirstOrDefault()?.Url)" />
+<meta property="og:image" content="@(Model.MetadataOgImage?.FirstOrDefault()?.Url)" />
 <meta property="og:description" content="@Model.MetadataOgDescription" />
 
 <meta name="twitter:card" content="summary_large_image">
@@ -13,4 +13,4 @@
 <meta name="twitter:creator" content="@Model.MetadataTwitterCreator">
 <meta name="twitter:title" content="@Model.MetadataTwitterTitle">
 <meta name="twitter:description" content="@Model.MetadataOgDescription">
-<meta name="twitter:image" content="@(Model.MetadataTwitterImage.FirstOrDefault()?.Url)">
+<meta name="twitter:image" content="@(Model.MetadataTwitterImage?.FirstOrDefault()?.Url)">


### PR DESCRIPTION
Prevent server errors when accessing content from older sample projects without home page metadata. As the Home content type in older sample projects does not contain elements with page metadata, e.g. metadata__twitter_image, the asset collection in strongly-typed model is null and rendering of the home page fails. See DEL-1894 for more information. 