### PR TITLE
ET-283 - EditLinkHelper returns still the same projectId instance for link builder

### DIFF
--- a/DancingGoat/Helpers/EditLinkHelper.cs
+++ b/DancingGoat/Helpers/EditLinkHelper.cs
@@ -1,5 +1,4 @@
-﻿using DancingGoat.Areas.Admin;
-using DancingGoat.Utils;
+﻿using DancingGoat.Utils;
 using KenticoCloud.ContentManagement.Helpers;
 using KenticoCloud.ContentManagement.Helpers.Configuration;
 
@@ -7,33 +6,10 @@ namespace DancingGoat.Helpers
 {
     public sealed class EditLinkHelper
     {
-        private static EditLinkHelper _instance = null;
-        private static readonly object padlock = new object();
-        public EditLinkBuilder Builder { get; private set; }
-
-        private EditLinkHelper()
-        {
+        public static EditLinkBuilder GetBuilder() {
             var projectId = ProjectUtils.GetProjectId();
             var linkBuilderOptions = new ContentManagementHelpersOptions() { ProjectId = projectId };
-            Builder = new EditLinkBuilder(linkBuilderOptions);
-        }
-
-        public static EditLinkHelper Instance
-        {
-            get
-            {
-                if (_instance == null)
-                {
-                    lock (padlock)
-                    {
-                        if (_instance == null)
-                        {
-                            _instance = new EditLinkHelper();
-                        }
-                    }
-                }
-                return _instance;
-            }
+            return new EditLinkBuilder(linkBuilderOptions);
         }
     }
 }

--- a/DancingGoat/Helpers/Extensions/HtmlHelperExtensions.cs
+++ b/DancingGoat/Helpers/Extensions/HtmlHelperExtensions.cs
@@ -248,12 +248,12 @@ namespace DancingGoat.Helpers.Extensions
 
         private static string GetItemUrl(string language, string itemId)
         {
-            return EditLinkHelper.Instance.Builder.BuildEditItemUrl(language, itemId);
+            return EditLinkHelper.GetBuilder().BuildEditItemUrl(language, itemId);
         }
 
         private static string GetItemElementUrl(string language, params ElementIdentifier[] elementIdentifiers)
         {
-            return EditLinkHelper.Instance.Builder.BuildEditItemUrl(language, elementIdentifiers);
+            return EditLinkHelper.GetBuilder().BuildEditItemUrl(language, elementIdentifiers);
         }
 
         private static string GenerateSrcsetValue(string imageUrl)


### PR DESCRIPTION
EditLinkHelper creates Builder which is a singleton. This means there is static (and only one) Builder instance with same projectId all the time. This causes invalid edit links (still the same projectId).

How to fix: Builder mustn't be a singleton and must be instantiated according to current projectId.

